### PR TITLE
Add correlation metric

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 
 option(MV_UMAP_USE_OPENMP "Use OpenMP - by default ON" ON)
 option(MV_UMAP_USE_AVX "Use AVX if available - by default OFF" OFF)
+option(MV_UMAP_UNIT_TESTS "Create unit tests - by default OFF" OFF)
 
 # Set DOWNLOAD_EXTRACT_TIMESTAMP option to the time of the extraction, added in 3.24
 if(POLICY CMP0135)
@@ -94,9 +95,12 @@ endif()
 # Source files
 # -----------------------------------------------------------------------------
 # Define the plugin sources
-set(UMAPANALYSIS_SOURCES
+set(UMAPANALYSIS_PLUGIN
     src/UMAPAnalysisPlugin.h
     src/UMAPAnalysisPlugin.cpp
+)
+
+set(UMAPANALYSIS_SETTINGS
     src/SettingsAction.h
     src/SettingsAction.cpp
     src/KnnSettingsAction.h
@@ -105,10 +109,23 @@ set(UMAPANALYSIS_SOURCES
     src/AdvancedSettingsAction.cpp
 )
 
+set(UMAPANALYSIS_DISTANCES
+    src/hnsw/space_corr.h
+)
+
 set(UMAPANALYSIS_AUX
     PluginInfo.json
 )
-source_group(Plugin FILES ${UMAPANALYSIS_SOURCES})
+
+set(UMAPANALYSIS_SOURCES
+    ${UMAPANALYSIS_PLUGIN}
+    ${UMAPANALYSIS_SETTINGS}
+    ${UMAPANALYSIS_DISTANCES}
+)
+
+source_group(Plugin FILES ${UMAPANALYSIS_PLUGIN})
+source_group(Settings FILES ${UMAPANALYSIS_SETTINGS})
+source_group(Distances FILES ${UMAPANALYSIS_DISTANCES})
 source_group(Aux FILES ${UMAPANALYSIS_AUX})
 
 # -----------------------------------------------------------------------------
@@ -180,4 +197,12 @@ mv_handle_plugin_config(${UMAPANALYSIS})
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set_property(TARGET ${UMAPANALYSIS} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<IF:$<CONFIG:DEBUG>,${ManiVault_INSTALL_DIR}/Debug,$<IF:$<CONFIG:RELWITHDEBINFO>,${ManiVault_INSTALL_DIR}/RelWithDebInfo,${ManiVault_INSTALL_DIR}/Release>>)
     set_property(TARGET ${UMAPANALYSIS} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,"${ManiVault_INSTALL_DIR}/Debug/ManiVault Studio.exe",$<IF:$<CONFIG:RELWITHDEBINFO>,"${ManiVault_INSTALL_DIR}/RelWithDebInfo/ManiVault Studio.exe","${ManiVault_INSTALL_DIR}/Release/ManiVault Studio.exe">>)
+endif()
+
+# -----------------------------------------------------------------------------
+# Unit testing
+# -----------------------------------------------------------------------------
+if(${MV_UMAP_UNIT_TESTS})
+	MESSAGE( STATUS "Build UMAP unit tests")
+	add_subdirectory("test")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ endif()
 # -----------------------------------------------------------------------------
 set(UMAPANALYSIS "UMAPAnalysisPlugin")
 PROJECT(${UMAPANALYSIS} 
-        VERSION 1.2.0
         DESCRIPTION "A ManiVault plugin that wraps LTLA/umappp"
         LANGUAGES CXX)
 

--- a/PluginInfo.json
+++ b/PluginInfo.json
@@ -1,7 +1,7 @@
 {
     "name" : "UMAP Analysis",
     "version" :  {
-        "plugin" : "1.3.0",
+        "plugin" : "1.4.0",
         "core" : ["1.4"]
     },
     "type" : "Analysis",

--- a/README.md
+++ b/README.md
@@ -35,17 +35,17 @@ Advanced settings:
 - `learning_rate`: Initial learning rate used in the gradient descent. Larger values can improve the speed of convergence but at the cost of stability.
 - `seed`: Seed to use for the Mersenne Twister when sampling negative observations.
 
-knn Settings:
-- `Algorithm`: Type of approximated knn algorithm/library to be used. Either [Annoy](https://github.com/spotify/annoy) or [HNSW](https://github.com/nmslib/hnswlib/).
+knn settings:
 - `Number knn`:  Number of neighbors to use to define the fuzzy sets. Larger values improve connectivity and favor preservation of global structure, at the cost of increased computational work.
 - `Multithreading`: Whether to use all available threads for knn computation. This will be faster while using more memory.
-- (Annoy) Trees & Checks: correspond to `n_trees` and `search_k`, see their [docs](https://github.com/spotify/annoy?tab=readme-ov-file#tradeoffs)
-- (HNSW): M & ef: are detailed in the respective [docs](https://github.com/nmslib/hnswlib/blob/master/ALGO_PARAMS.md#hnsw-algorithm-parameters)
+- `Algorithm`: Type of approximated knn algorithm/library to be used. Either [Annoy](https://github.com/spotify/annoy) or [HNSW](https://github.com/nmslib/hnswlib/).
+  - `Annoy Trees` & `Annoy Checks`: correspond to `n_trees` and `search_k`, see the respective [Annoy docs](https://github.com/spotify/annoy?tab=readme-ov-file#tradeoffs)
+  - `HNSW M` & `HNSW ef`: are detailed in the respective [HNSW docs](https://github.com/nmslib/hnswlib/blob/master/ALGO_PARAMS.md#hnsw-algorithm-parameters)
 - `Metric`:
   - Euclidean (L2): `sum((Ai-Bi)^2)`
   - Cosine: `1.0 - sum(Ai*Bi)`
   - Inner: `1.0 - sum(Ai*Bi) / sqrt(sum(Ai*Ai) * sum(Bi*Bi))`
-  - Correlation: `1.0 - corr(A, B)`. Based on [Pearson's correlation coefficient](https://en.wikipedia.org/wiki/Correlation) between data vectors. See the correlation distance in [umap-learn](https://github.com/lmcinnes/umap/blob/15e55bb6a1ca23b8d6040d9d6184a7ae98325ace/umap/distances.py#L598). Only available with HNSW. (Technically not a metric)
+  - Correlation: `1.0 - corr(A, B)`. Based on [Pearson's correlation coefficient](https://en.wikipedia.org/wiki/Correlation) between data vectors. See the correlation distance in [umap-learn](https://github.com/lmcinnes/umap/blob/15e55bb6a1ca23b8d6040d9d6184a7ae98325ace/umap/distances.py#L598). Only available with HNSW. (Technically not a metric.)
 
 ## References
 - [libscran/umappp](https://github.com/libscran/umappp): Aaron Lun, BSD 2-Clause License

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ knn Settings:
 - `Multithreading`: Whether to use all available threads for knn computation. This will be faster while using more memory.
 - (Annoy) Trees & Checks: correspond to `n_trees` and `search_k`, see their [docs](https://github.com/spotify/annoy?tab=readme-ov-file#tradeoffs)
 - (HNSW): M & ef: are detailed in the respective [docs](https://github.com/nmslib/hnswlib/blob/master/ALGO_PARAMS.md#hnsw-algorithm-parameters)
+- `Metric`:
+  - Euclidean (L2): `sum((Ai-Bi)^2)`
+  - Cosine: `1.0 - sum(Ai*Bi)`
+  - Inner: `1.0 - sum(Ai*Bi) / sqrt(sum(Ai*Ai) * sum(Bi*Bi))`
+  - Correlation: `1.0 - corr(A, B)`. Based on [Pearson's correlation coefficient](https://en.wikipedia.org/wiki/Correlation) between data vectors. See the correlation distance in [umap-learn](https://github.com/lmcinnes/umap/blob/15e55bb6a1ca23b8d6040d9d6184a7ae98325ace/umap/distances.py#L598). Only available with HNSW. (Technically not a metric)
 
 ## References
 - [libscran/umappp](https://github.com/libscran/umappp): Aaron Lun, BSD 2-Clause License

--- a/src/KnnSettingsAction.cpp
+++ b/src/KnnSettingsAction.cpp
@@ -72,23 +72,35 @@ KnnSettingsAction::KnnSettingsAction(QObject* parent) :
 #endif // !NDEBUG
 
     const auto updateKnnAlgorithm = [this]() -> void {
-        if(_knnAlgorithm.getCurrentIndex() == 0)
-            _knnParameters.setKnnAlgorithm(KnnAlgorithm::ANNOY);
-        else if (_knnAlgorithm.getCurrentIndex() == 1)
-            _knnParameters.setKnnAlgorithm(KnnAlgorithm::HNSW);
+        auto currentAlgorithmIntex = _knnAlgorithm.getCurrentIndex();
+
+        KnnAlgorithm newAlg = KnnAlgorithm::HNSW;
+
+        if(currentAlgorithmIntex == 0)
+            newAlg = KnnAlgorithm::ANNOY;
+        else if (currentAlgorithmIntex == 1)
+            newAlg = KnnAlgorithm::HNSW;
+
+        _knnParameters.setKnnAlgorithm(newAlg);
         };
 
     const auto updateKnnMetric = [this]() -> void {
-        if(_knnAlgorithm.getCurrentIndex() == 0)
-            _knnParameters.setKnnMetric(KnnMetric::EUCLIDEAN);
-        else if (_knnAlgorithm.getCurrentIndex() == 1)
-            _knnParameters.setKnnMetric(KnnMetric::COSINE);
-        else if (_knnAlgorithm.getCurrentIndex() == 2)
-            _knnParameters.setKnnMetric(KnnMetric::DOT);
-        else if (_knnAlgorithm.getCurrentIndex() == 3) {
-            _knnAlgorithm.setCurrentIndex(0); // only implemented for hnsw
-            _knnParameters.setKnnMetric(KnnMetric::CORRELATION);
+        auto currentMetricIntex = _knnMetric.getCurrentIndex();
+
+        KnnMetric newMetric = KnnMetric::EUCLIDEAN;
+
+        if(currentMetricIntex == 0)
+            newMetric = KnnMetric::EUCLIDEAN;
+        else if (currentMetricIntex == 1)
+            newMetric = KnnMetric::COSINE;
+        else if (currentMetricIntex == 2)
+            newMetric = KnnMetric::DOT;
+        else if (currentMetricIntex == 3) {
+            newMetric = KnnMetric::CORRELATION;
+            _knnAlgorithm.setCurrentIndex(1); // only implemented for hnsw
         }
+
+        _knnParameters.setKnnMetric(newMetric);
         };
 
     const auto updateNumTrees = [this]() -> void {

--- a/src/KnnSettingsAction.h
+++ b/src/KnnSettingsAction.h
@@ -5,9 +5,11 @@
 #include "actions/OptionAction.h"
 #include "actions/ToggleAction.h"
 
+#include <string>
+
 using namespace mv::gui;
 
-enum class KnnLibrary {
+enum class KnnAlgorithm {
     ANNOY,
     HNSW,
 };
@@ -16,14 +18,18 @@ enum class KnnMetric {
     EUCLIDEAN,
     COSINE,
     DOT,
+    CORRELATION,     // only works with hnsw
 };
+
+std::string printAlgorithm(const KnnAlgorithm& a);
+std::string printMetric(const KnnMetric& m);
 
 class KnnParameters
 {
 public:
     KnnParameters() :
-        _knnLibrary(KnnLibrary::ANNOY),
-        _knn_metric(KnnMetric::EUCLIDEAN),
+        _knnAlgorithm(KnnAlgorithm::ANNOY),
+        _knnMetric(KnnMetric::EUCLIDEAN),
         _k(20),
         _AnnoyNumChecksAknn(512),
         _AnnoyNumTrees(8),
@@ -33,16 +39,16 @@ public:
 
     }
 
-    void setKnnAlgorithm(KnnLibrary knnLibrary) { _knnLibrary = knnLibrary; }
-    void setKnnDistanceMetric(KnnMetric knnDistanceMetric) { _knn_metric = knnDistanceMetric; }
+    void setKnnAlgorithm(KnnAlgorithm knnLibrary) { _knnAlgorithm = knnLibrary; }
+    void setKnnMetric(KnnMetric knnDistanceMetric) { _knnMetric = knnDistanceMetric; }
     void setK(int k) { _k = k; }
     void setAnnoyNumChecks(int numChecks) { _AnnoyNumChecksAknn = numChecks; }
     void setAnnoyNumTrees(int numTrees) { _AnnoyNumTrees = numTrees; }
     void setHNSWm(int m) { _HNSW_M = m; }
     void setHNSWef(int ef) { _HNSW_ef_construction = ef; }
 
-    KnnLibrary getKnnAlgorithm() const { return _knnLibrary; }
-    KnnMetric getKnnDistanceMetric() const { return _knn_metric; }
+    KnnAlgorithm getKnnAlgorithm() const { return _knnAlgorithm; }
+    KnnMetric getKnnMetric() const { return _knnMetric; }
     int getK() const { return _k; }
     int getAnnoyNumChecks() const { return _AnnoyNumChecksAknn; }
     int getAnnoyNumTrees() const { return _AnnoyNumTrees; }
@@ -51,16 +57,16 @@ public:
 
 private:
 
-    KnnLibrary _knnLibrary;     /** Enum specifying which approximate nearest neighbour library to use for the similarity computation */
-    KnnMetric _knn_metric;      /** Enum specifying which distance to compute knn with */
+    KnnAlgorithm    _knnAlgorithm;              /** Enum specifying which approximate nearest neighbour library to use for the similarity computation */
+    KnnMetric       _knnMetric;                 /** Enum specifying which distance to compute knn with */
 
-    int _k;                     /** Number of neighbors */
+    int             _k;                         /** Number of neighbors */
 
-    int _AnnoyNumChecksAknn;                        /** Number of checks used in Annoy, more checks means more precision but slower computation */
-    int _AnnoyNumTrees;                             /** Number of trees used in Annoy, more checks means more precision but slower computation */
+    int             _AnnoyNumChecksAknn;        /** Number of checks used in Annoy, more checks means more precision but slower computation */
+    int             _AnnoyNumTrees;             /** Number of trees used in Annoy, more checks means more precision but slower computation */
 
-    int            _HNSW_M;                         /** hnsw: construction time/accuracy trade-off  */
-    int            _HNSW_ef_construction;           /** hnsw: maximum number of outgoing connections in the graph  */
+    int             _HNSW_M;                    /** hnsw: construction time/accuracy trade-off  */
+    int             _HNSW_ef_construction;      /** hnsw: maximum number of outgoing connections in the graph  */
 };
 
 
@@ -104,6 +110,7 @@ protected:
     KnnParameters           _knnParameters;             /** Knn parameters */
 
     OptionAction            _knnAlgorithm;              /** Annoy or HNSW */
+    OptionAction            _knnMetric;                 /** Euclidean, Cosine, Dot, etc. */
     IntegralAction          _kAction;                   /** Number of kNN */
     ToggleAction            _multithreadActions;        /** Whether to use multiple threads */
     IntegralAction          _numTreesAction;            /** Annoy parameter Trees action */

--- a/src/UMAPAnalysisPlugin.cpp
+++ b/src/UMAPAnalysisPlugin.cpp
@@ -306,7 +306,7 @@ void UMAPWorker::compute()
     const KnnParameters knnParams = _knnSettingsAction->getKnnParameters();
     const int numNeighbors = knnParams.getK();
     {
-        qDebug() << "UMAP: compute knn: " << numNeighbors << " neighbors based on " << printMetric(knnParams.getKnnMetric()) << " with " << printAlgorithm(knnParams.getKnnAlgorithm());
+        qDebug() << "UMAP: compute knn: " << numNeighbors << " neighbors based on " << printMetric(knnParams.getKnnMetric()) << " distance with " << printAlgorithm(knnParams.getKnnAlgorithm());
 
         std::unique_ptr<KnnBase> searcher;
         const auto mat = DataMatrix(static_cast<size_t>(numEnabledDimensions), numPoints, data.data());

--- a/src/UMAPAnalysisPlugin.cpp
+++ b/src/UMAPAnalysisPlugin.cpp
@@ -430,6 +430,7 @@ void UMAPWorker::compute()
         _computeTask->setProgress(epoch / static_cast<float>(numberOfEpochs));
         _computeTask->setProgressDescription(QString("Epoch %1/%2").arg(QString::number(epoch), QString::number(numberOfEpochs)));
         _settingsAction->getCurrentEpochAction().setString(QString::number(epoch));
+        QCoreApplication::processEvents();
     }
 
     updateEmbedding(epoch);

--- a/src/UMAPAnalysisPlugin.cpp
+++ b/src/UMAPAnalysisPlugin.cpp
@@ -306,12 +306,10 @@ void UMAPWorker::compute()
     const KnnParameters knnParams = _knnSettingsAction->getKnnParameters();
     const int numNeighbors = knnParams.getK();
     {
-        int nDim = numEnabledDimensions;
-
         qDebug() << "UMAP: compute knn: " << numNeighbors << " neighbors based on " << printMetric(knnParams.getKnnMetric()) << " with " << printAlgorithm(knnParams.getKnnAlgorithm());
 
         std::unique_ptr<KnnBase> searcher;
-        const auto mat = DataMatrix(nDim, numPoints, data.data());
+        const auto mat = DataMatrix(static_cast<size_t>(numEnabledDimensions), numPoints, data.data());
 
         if (knnParams.getKnnAlgorithm() == KnnAlgorithm::ANNOY) {
             knncolle_annoy::AnnoyOptions opt;

--- a/src/UMAPAnalysisPlugin.cpp
+++ b/src/UMAPAnalysisPlugin.cpp
@@ -33,6 +33,7 @@
 #include <QDebug>
 #include <QtCore>
 
+#include <algorithm>
 #include <cmath>
 
 #ifdef _OPENMP

--- a/src/hnsw/space_corr.h
+++ b/src/hnsw/space_corr.h
@@ -1,0 +1,298 @@
+#pragma once
+
+#include "hnswlib/hnswlib.h"
+
+#include <cmath>
+
+namespace hnswlib {
+
+
+static float
+    CorrelationDistance(const void* pVect1, const void* pVect2, const void* qty_ptr) {
+    size_t qty = *((size_t*)qty_ptr);
+    float* v1 = (float*)pVect1;
+    float* v2 = (float*)pVect2;
+
+    // Calculate means
+    float mu_x = 0.0f;
+    float mu_y = 0.0f;
+    for (size_t i = 0; i < qty; i++) {
+        mu_x += v1[i];
+        mu_y += v2[i];
+    }
+    mu_x /= qty;
+    mu_y /= qty;
+
+    // Calculate correlation components
+    float norm_x = 0.0f;
+    float norm_y = 0.0f;
+    float dot_product = 0.0f;
+
+    for (size_t i = 0; i < qty; i++) {
+        float shifted_x = v1[i] - mu_x;
+        float shifted_y = v2[i] - mu_y;
+        norm_x += shifted_x * shifted_x;
+        norm_y += shifted_y * shifted_y;
+        dot_product += shifted_x * shifted_y;
+    }
+
+    if (norm_x == 0.0f && norm_y == 0.0f) {
+        return 0.0f;
+    }
+    else if (dot_product == 0.0f) {
+        return 1.0f;
+    }
+    else {
+        return 1.0f - (dot_product / std::sqrt(norm_x * norm_y));
+    }
+}
+
+#if defined(USE_AVX)
+
+static float
+CorrelationDistanceSIMD8ExtAVX(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
+    float* pVect1 = (float*)pVect1v;
+    float* pVect2 = (float*)pVect2v;
+    size_t qty = *((size_t*)qty_ptr);
+
+    size_t qty8 = qty / 8;
+    const float* pEnd1 = pVect1 + 8 * qty8;
+
+    // Calculate means using SIMD
+    __m256 sum1 = _mm256_set1_ps(0.0f);
+    __m256 sum2 = _mm256_set1_ps(0.0f);
+
+    float* p1 = pVect1;
+    float* p2 = pVect2;
+
+    while (p1 < pEnd1) {
+        __m256 v1 = _mm256_loadu_ps(p1);
+        __m256 v2 = _mm256_loadu_ps(p2);
+        sum1 = _mm256_add_ps(sum1, v1);
+        sum2 = _mm256_add_ps(sum2, v2);
+        p1 += 8;
+        p2 += 8;
+    }
+
+    // Extract and sum the elements
+    float PORTABLE_ALIGN32 tmp1[8], tmp2[8];
+    _mm256_store_ps(tmp1, sum1);
+    _mm256_store_ps(tmp2, sum2);
+
+    float mu_x = 0.0f, mu_y = 0.0f;
+    for (int i = 0; i < 8; i++) {
+        mu_x += tmp1[i];
+        mu_y += tmp2[i];
+    }
+
+    // Add remaining elements
+    for (size_t i = qty8 * 8; i < qty; i++) {
+        mu_x += pVect1[i];
+        mu_y += pVect2[i];
+    }
+
+    mu_x /= qty;
+    mu_y /= qty;
+
+    // Calculate correlation components using SIMD
+    __m256 mu_x_vec = _mm256_set1_ps(mu_x);
+    __m256 mu_y_vec = _mm256_set1_ps(mu_y);
+    __m256 norm_x_vec = _mm256_set1_ps(0.0f);
+    __m256 norm_y_vec = _mm256_set1_ps(0.0f);
+    __m256 dot_vec = _mm256_set1_ps(0.0f);
+
+    p1 = pVect1;
+    p2 = pVect2;
+
+    while (p1 < pEnd1) {
+        __m256 v1 = _mm256_loadu_ps(p1);
+        __m256 v2 = _mm256_loadu_ps(p2);
+
+        __m256 shifted_x = _mm256_sub_ps(v1, mu_x_vec);
+        __m256 shifted_y = _mm256_sub_ps(v2, mu_y_vec);
+
+        norm_x_vec = _mm256_add_ps(norm_x_vec, _mm256_mul_ps(shifted_x, shifted_x));
+        norm_y_vec = _mm256_add_ps(norm_y_vec, _mm256_mul_ps(shifted_y, shifted_y));
+        dot_vec = _mm256_add_ps(dot_vec, _mm256_mul_ps(shifted_x, shifted_y));
+
+        p1 += 8;
+        p2 += 8;
+    }
+
+    // Extract results
+    float PORTABLE_ALIGN32 norm_x_tmp[8], norm_y_tmp[8], dot_tmp[8];
+    _mm256_store_ps(norm_x_tmp, norm_x_vec);
+    _mm256_store_ps(norm_y_tmp, norm_y_vec);
+    _mm256_store_ps(dot_tmp, dot_vec);
+
+    float norm_x = 0.0f, norm_y = 0.0f, dot_product = 0.0f;
+    for (int i = 0; i < 8; i++) {
+        norm_x += norm_x_tmp[i];
+        norm_y += norm_y_tmp[i];
+        dot_product += dot_tmp[i];
+    }
+
+    // Handle remaining elements
+    for (size_t i = qty8 * 8; i < qty; i++) {
+        float shifted_x = pVect1[i] - mu_x;
+        float shifted_y = pVect2[i] - mu_y;
+        norm_x += shifted_x * shifted_x;
+        norm_y += shifted_y * shifted_y;
+        dot_product += shifted_x * shifted_y;
+    }
+
+    if (norm_x == 0.0f && norm_y == 0.0f) {
+        return 0.0f;
+    }
+    else if (dot_product == 0.0f) {
+        return 1.0f;
+    }
+    else {
+        return 1.0f - (dot_product / std::sqrt(norm_x * norm_y));
+    }
+}
+
+#endif // USE_AVX
+
+#if defined(USE_SSE)
+
+static float
+CorrelationDistanceSIMD4ExtSSE(const void* pVect1v, const void* pVect2v, const void* qty_ptr) {
+    float* pVect1 = (float*)pVect1v;
+    float* pVect2 = (float*)pVect2v;
+    size_t qty = *((size_t*)qty_ptr);
+
+    size_t qty4 = qty / 4;
+    const float* pEnd1 = pVect1 + 4 * qty4;
+
+    // Calculate means using SIMD
+    __m128 sum1 = _mm_set1_ps(0.0f);
+    __m128 sum2 = _mm_set1_ps(0.0f);
+
+    float* p1 = pVect1;
+    float* p2 = pVect2;
+
+    while (p1 < pEnd1) {
+        __m128 v1 = _mm_loadu_ps(p1);
+        __m128 v2 = _mm_loadu_ps(p2);
+        sum1 = _mm_add_ps(sum1, v1);
+        sum2 = _mm_add_ps(sum2, v2);
+        p1 += 4;
+        p2 += 4;
+    }
+
+    // Extract and sum the elements
+    float PORTABLE_ALIGN32 tmp1[4], tmp2[4];
+    _mm_store_ps(tmp1, sum1);
+    _mm_store_ps(tmp2, sum2);
+
+    float mu_x = tmp1[0] + tmp1[1] + tmp1[2] + tmp1[3];
+    float mu_y = tmp2[0] + tmp2[1] + tmp2[2] + tmp2[3];
+
+    // Add remaining elements
+    for (size_t i = qty4 * 4; i < qty; i++) {
+        mu_x += pVect1[i];
+        mu_y += pVect2[i];
+    }
+
+    mu_x /= qty;
+    mu_y /= qty;
+
+    // Calculate correlation components using SIMD
+    __m128 mu_x_vec = _mm_set1_ps(mu_x);
+    __m128 mu_y_vec = _mm_set1_ps(mu_y);
+    __m128 norm_x_vec = _mm_set1_ps(0.0f);
+    __m128 norm_y_vec = _mm_set1_ps(0.0f);
+    __m128 dot_vec = _mm_set1_ps(0.0f);
+
+    p1 = pVect1;
+    p2 = pVect2;
+
+    while (p1 < pEnd1) {
+        __m128 v1 = _mm_loadu_ps(p1);
+        __m128 v2 = _mm_loadu_ps(p2);
+
+        __m128 shifted_x = _mm_sub_ps(v1, mu_x_vec);
+        __m128 shifted_y = _mm_sub_ps(v2, mu_y_vec);
+
+        norm_x_vec = _mm_add_ps(norm_x_vec, _mm_mul_ps(shifted_x, shifted_x));
+        norm_y_vec = _mm_add_ps(norm_y_vec, _mm_mul_ps(shifted_y, shifted_y));
+        dot_vec = _mm_add_ps(dot_vec, _mm_mul_ps(shifted_x, shifted_y));
+
+        p1 += 4;
+        p2 += 4;
+    }
+
+    // Extract results
+    float PORTABLE_ALIGN32 norm_x_tmp[4], norm_y_tmp[4], dot_tmp[4];
+    _mm_store_ps(norm_x_tmp, norm_x_vec);
+    _mm_store_ps(norm_y_tmp, norm_y_vec);
+    _mm_store_ps(dot_tmp, dot_vec);
+
+    float norm_x = norm_x_tmp[0] + norm_x_tmp[1] + norm_x_tmp[2] + norm_x_tmp[3];
+    float norm_y = norm_y_tmp[0] + norm_y_tmp[1] + norm_y_tmp[2] + norm_y_tmp[3];
+    float dot_product = dot_tmp[0] + dot_tmp[1] + dot_tmp[2] + dot_tmp[3];
+
+    // Handle remaining elements
+    for (size_t i = qty4 * 4; i < qty; i++) {
+        float shifted_x = pVect1[i] - mu_x;
+        float shifted_y = pVect2[i] - mu_y;
+        norm_x += shifted_x * shifted_x;
+        norm_y += shifted_y * shifted_y;
+        dot_product += shifted_x * shifted_y;
+    }
+
+    if (norm_x == 0.0f && norm_y == 0.0f) {
+        return 0.0f;
+    }
+    else if (dot_product == 0.0f) {
+        return 1.0f;
+    }
+    else {
+        return 1.0f - (dot_product / std::sqrt(norm_x * norm_y));
+    }
+}
+
+#endif // USE_SSE
+
+
+class CorrelationSpace : public SpaceInterface<float> {
+    DISTFUNC<float> fstdistfunc_;
+    size_t data_size_;
+    size_t dim_;
+
+ public:
+    CorrelationSpace(size_t dim) {
+
+        fstdistfunc_ = CorrelationDistance;
+
+#if defined(USE_SSE)
+        if (dim > 4)
+            fstdistfunc_ = CorrelationDistanceSIMD4ExtSSE;
+#endif
+
+#if defined(USE_AVX)
+        if (dim > 8)
+            fstdistfunc_ = CorrelationDistanceSIMD8ExtAVX;
+#endif
+
+        dim_ = dim;
+        data_size_ = dim * sizeof(float);
+    }
+
+    size_t get_data_size() {
+        return data_size_;
+    }
+
+    DISTFUNC<float> get_dist_func() {
+        return fstdistfunc_;
+    }
+
+    void *get_dist_func_param() {
+        return &dim_;
+    }
+
+~CorrelationSpace() {}
+};
+
+}  // namespace hnswlib

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,79 @@
+cmake_minimum_required(VERSION 3.22)
+
+# -----------------------------------------------------------------------------
+# Project: UMAP plugin testing
+# -----------------------------------------------------------------------------
+set(UMAP_TESTS "UmapTests")
+
+# Setup of test build depends on setup of parent project, the plugin itself
+
+PROJECT(${UMAP_TESTS})
+
+# -----------------------------------------------------------------------------
+# Dependencies
+# -----------------------------------------------------------------------------
+
+include(FetchContent)
+FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2
+    GIT_TAG v3.8.1
+    GIT_SHALLOW TRUE
+    FIND_PACKAGE_ARGS
+)
+FetchContent_MakeAvailable(Catch2)
+
+find_package(Catch2 CONFIG REQUIRED)
+
+# -----------------------------------------------------------------------------
+# Source files
+# -----------------------------------------------------------------------------
+
+set(SOURCES
+    test_main.cpp
+	test_utils.h
+)
+
+source_group( UmapTests FILES ${SOURCES})
+
+# -----------------------------------------------------------------------------
+# CMake Target
+# -----------------------------------------------------------------------------
+
+add_executable(${UMAP_TESTS} ${SOURCES})
+
+# -----------------------------------------------------------------------------
+# Target include directories
+# -----------------------------------------------------------------------------
+
+# Include umap 
+set(UMAP_PLUGIN_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_include_directories(${UMAP_TESTS} PRIVATE "${UMAP_PLUGIN_DIR}/src")
+
+# -----------------------------------------------------------------------------
+# Target link directories
+# -----------------------------------------------------------------------------
+target_link_libraries(${UMAP_TESTS} PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(${UMAP_TESTS} PRIVATE Eigen3::Eigen)
+
+target_link_libraries(${UMAP_TESTS} PRIVATE knncolle::knncolle_hnsw)
+
+if(${MV_UMAP_USE_OPENMP} AND OpenMP_CXX_FOUND)
+	message(STATUS "Link ${UMAP_TESTS} to OpenMP")
+	target_link_libraries(${UMAP_TESTS} PRIVATE OpenMP::OpenMP_CXX)
+endif()
+
+# -----------------------------------------------------------------------------
+# Target properties
+# -----------------------------------------------------------------------------
+
+# Request C++17
+target_compile_features(${UMAP_TESTS} PRIVATE cxx_std_20)
+target_compile_features(${UMAP_TESTS} PRIVATE c_std_17)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(${UMAP_TESTS} PRIVATE /bigobj)    # for Eigen
+endif()
+
+# Instruction sets
+mv_check_and_set_AVX(${UMAP_TESTS} ${MV_UMAP_USE_AVX})

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,9 @@
+# UMAP Plugin Test
+Run `python create_reference_data.py` in this directory to print reference values used in the tests.
+
+The reference values are created in python using [umap-learn](https://umap-learn.readthedocs.io) and [numpy](https://numpy.org/).
+
+## Dependencies:
+The test setup depends on the plugin project. 
+One extra dependencies is automatically downloaded during the cmake configuration: 
+- [Catch2](https://github.com/catchorg/Catch2) for unit testing

--- a/test/create_reference_data.py
+++ b/test/create_reference_data.py
@@ -1,0 +1,38 @@
+from umap.distances import correlation as umap_correlation_dist
+import numpy as np
+
+x1 = np.array([1, 2, 3, 4, 5])
+y1 = np.array([1, 2, 3, 4, 5])  # perfect positive correlation
+
+x2 = np.array([1, 2, 3, 4, 5])
+y2 = np.array([5, 4, 3, 2, 1])  # perfect negative correlation
+
+x3 = np.array([1, -1, 1, -1])
+y3 = np.array([1, 1, -1, -1])   # zero correlation
+
+x4 = np.array([5])
+y4 = np.array([3])
+
+x5 = np.array([1, 2])
+y5 = np.array([3, 4])
+
+x6 = np.array([0, 1, 0, 1])
+y6 = np.array([1, 0, 1, 0])
+
+x7 = np.array([1, 1.5, 3, 7])
+y7 = np.array([1, 2.5, 2.9, 6])
+
+x8 = np.array([6, 6.5, 5.9, 3])
+y8 = np.array([2, 4.5, 5.2, 7])
+
+# Compute results
+print("Perfect positive correlation:", umap_correlation_dist(x1, y1))   # Expect ~0.0
+print("Perfect negative correlation:", umap_correlation_dist(x2, y2))   # Expect ~2.0
+print("No correlation:", umap_correlation_dist(x3, y3))                 # Expect ~1.0
+
+print("Edge case 1:", umap_correlation_dist(x4, y4))                    # Expect ~0.0
+print("Edge case 2:", umap_correlation_dist(x5, y5))                    # Expect ~0.0
+print("Edge case 3:", umap_correlation_dist(x6, y6))                    # Expect ~2.0
+
+print("Positive correlation:", umap_correlation_dist(x7, y7))           # Expect ~0.0249
+print("Negative correlation:", umap_correlation_dist(x8, y8))           # Expect ~1.7209

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,2 @@
+umap-learn~=0.5.0
+numpy~=1.26.0

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,0 +1,202 @@
+#include <catch2/catch_test_macros.hpp>	// for info on testing see https://github.com/catchorg/Catch2/blob/devel/docs/tutorial.md#test-cases-and-sections
+
+#include "test_utils.h"
+
+#include "hnsw/space_corr.h"
+
+#include <vector>
+
+using namespace testing;
+
+static void testInstructionSets(const float ref, const std::vector<float>& vec1, const std::vector<float>& vec2, const size_t dim) {
+#if defined(USE_SSE)
+	float test_sse = hnswlib::CorrelationDistanceSIMD4ExtSSE(vec1.data(), vec2.data(), &dim);
+	expectNear(test_sse, ref, 1e-6f, "Reference should be same as SSE results");
+#endif
+
+#if defined(USE_AVX)
+	float test_avx = hnswlib::CorrelationDistanceSIMD8ExtAVX(vec1.data(), vec2.data(), &dim);
+	expectNear(test_avx, ref, 1e-6f, "Reference should be same as AVX results");
+#endif
+}
+
+TEST_CASE("Correlation distance reference", "[DIST][CORR]") {
+
+	SECTION("Perfect positive correlation") {
+		std::vector<float> x = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f };
+		std::vector<float> y = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f };
+
+		size_t dim = x.size();
+
+		float ref = 0.0f;
+		float test = hnswlib::CorrelationDistance(x.data(), y.data(), &dim);
+
+		expectNear(test, ref, 0, "Perfect negative correlation");
+
+		testInstructionSets(ref, x, y, dim);
+	}
+
+	SECTION("Perfect negative correlation") {
+		std::vector<float> x = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f };
+		std::vector<float> y = { 5.0f, 4.0f, 3.0f, 2.0f, 1.0f };
+
+		size_t dim = x.size();
+
+		float ref = 2.0f;
+		float test = hnswlib::CorrelationDistance(x.data(), y.data(), &dim);
+
+		expectNear(test, ref, 0, "Perfect negative correlation");
+
+		testInstructionSets(ref, x, y, dim);
+	}
+
+	SECTION("Zero correlation") {
+		std::vector<float> x = { 1.0f, -1.0f, 1.0f, -1.0f };
+		std::vector<float> y = { 1.0f,  1.0f, -1.0f, -1.0f };
+
+		size_t dim = x.size();
+
+		float ref = 1.0f;
+		float test = hnswlib::CorrelationDistance(x.data(), y.data(), &dim);
+
+		expectNear(test, ref, 0, "Perfect negative correlation");
+
+		testInstructionSets(ref, x, y, dim);
+	}
+
+	SECTION("Positive correlation") {
+		std::vector<float> x = { 1.f, 1.5f, 3.f, 7.f };
+		std::vector<float> y = { 1.f, 2.5f, 2.9f, 6.f };
+
+		size_t dim = x.size();
+
+		float ref = 0.024905833f;
+		float test = hnswlib::CorrelationDistance(x.data(), y.data(), &dim);
+
+		expectNear(test, ref, 1e-6f, "Positive correlation");
+
+		testInstructionSets(ref, x, y, dim);
+	}
+
+	SECTION("Negative correlation") {
+		std::vector<float> x = { 6.f, 6.5f, 5.9f, 3.f };
+		std::vector<float> y = { 2.f, 4.5f, 5.2f, 7.f };
+
+		size_t dim = x.size();
+
+		float ref = 1.720908052f;
+		float test = hnswlib::CorrelationDistance(x.data(), y.data(), &dim);
+
+		expectNear(test, ref, 1e-6f, "Negative correlation");
+
+		testInstructionSets(ref, x, y, dim);
+	}
+
+}
+
+TEST_CASE("Correlation distance edge cases", "[DIST]") {
+	// Single element vectors
+	std::vector<float> vec1 = { 5.0f };
+	std::vector<float> vec2 = { 3.0f };
+	size_t dim = 1;
+
+	float ref = 0.0f;
+	float test1 = hnswlib::CorrelationDistance(vec1.data(), vec2.data(), &dim);
+	expectNear(test1, ref, 1e-6f, "Single element vectors");
+	testInstructionSets(ref, vec1, vec2, dim);
+
+	// Two element vectors
+	vec1 = { 1.0f, 2.0f };
+	vec2 = { 3.0f, 4.0f };
+	dim = 2;
+
+	ref = 0.0f;
+	float test2 = hnswlib::CorrelationDistance(vec1.data(), vec2.data(), &dim);
+	expectNear(test2, ref, 1e-6f, "Two element vectors");
+	testInstructionSets(ref, vec1, vec2, dim);
+
+	// Vectors with zeros
+	vec1 = { 0.0f, 1.0f, 0.0f, 1.0f };
+	vec2 = { 1.0f, 0.0f, 1.0f, 0.0f };
+	dim = 4;
+
+	ref = 2.0f;
+	float test3 = hnswlib::CorrelationDistance(vec1.data(), vec2.data(), &dim);
+	expectNear(test3, ref, 1e-6f, "Vectors with zeros");
+	testInstructionSets(ref, vec1, vec2, dim);
+}
+
+TEST_CASE("Correlation distance instruction sets", "[DIST][SSE][AVX]") {
+
+	DataGenerator data;
+
+	SECTION("Test identical vectors (should have correlation = 1, distance = 0)") {
+		auto vec1 = data.linearVector(16, 1.0f, 2.0f);
+		auto vec2 = vec1;
+		size_t dim = vec1.size();
+
+		float actual = hnswlib::CorrelationDistance(vec1.data(), vec2.data(), &dim);
+
+		expectNear(0.0f, actual, 1e-6f, "Identical vectors should have distance ~0");
+		testInstructionSets(actual, vec1, vec2, dim);
+	}
+
+	SECTION("Test constant vectors (undefined correlation, should return 0)") {
+		auto vec1 = data.constantVector(12, 5.0f);
+		auto vec2 = data.constantVector(12, 3.0f);
+		size_t dim = vec1.size();
+
+		float actual = hnswlib::CorrelationDistance(vec1.data(), vec2.data(), &dim);
+
+		expectNear(0.0f, actual, 1e-6f, "Constant vectors should return distance 0");
+		testInstructionSets(actual, vec1, vec2, dim);
+	}
+
+	SECTION("Test perfectly correlated vectors (should return 0)") {
+		auto vec1 = data.linearVector(20, 0.0f, 1.0f);  // [0, 1, 2, ..., 19]
+		auto vec2 = data.linearVector(20, 5.0f, 2.0f);  // [5, 7, 9, ..., 43]
+		size_t dim = vec1.size();
+
+		float actual = hnswlib::CorrelationDistance(vec1.data(), vec2.data(), &dim);
+
+		expectNear(0.0f, actual, 1e-6f, "Perfect positive correlation (should return distance 0)");
+		testInstructionSets(actual, vec1, vec2, dim);
+	}
+
+	SECTION("Test perfectly anti-correlated vectors (should return 2)") {
+		auto vec1 = data.linearVector(16, 0.0f, 1.0f);   // [0, 1, 2, ..., 15]
+		auto vec2 = data.linearVector(16, 15.0f, -1.0f); // [15, 14, 13, ..., 0]
+		size_t dim = vec1.size();
+
+		float actual = hnswlib::CorrelationDistance(vec1.data(), vec2.data(), &dim);
+
+		expectNear(2.0f, actual, 1e-6f, "Perfect negative  correlation (should return distance 2)");
+		testInstructionSets(actual, vec1, vec2, dim);
+	}
+
+	SECTION("Test orthogonal vectors (should return 1)") {
+		std::vector<float> vec1 = { 1.0f, 1.0f, 1.0f, 1.0f, -1.0f, -1.0f, -1.0f, -1.0f };
+		std::vector<float> vec2 = { 1.0f, -1.0f, 1.0f, -1.0f, 1.0f, -1.0f, 1.0f, -1.0f };
+		size_t dim = vec1.size();
+
+		float actual = hnswlib::CorrelationDistance(vec1.data(), vec2.data(), &dim);
+
+		expectNear(1.0f, actual, 1e-6f, "Zero correlation (should return distance 1)");
+		testInstructionSets(actual, vec1, vec2, dim);
+	}
+
+	SECTION("Random vectors") {
+
+		std::vector<size_t> test_sizes = { 4, 8, 12, 16, 20, 32, 64 };
+
+		for (size_t dim : test_sizes) {
+			auto vec1 = data.randomVector(dim);
+			auto vec2 = data.randomVector(dim);
+
+			float actual = hnswlib::CorrelationDistance(vec1.data(), vec2.data(), &dim);
+			testInstructionSets(actual, vec1, vec2, dim);
+		}
+	}
+
+
+}

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <iostream>
+#include <cmath>
+#include <random>
+#include <vector>
+
+namespace testing {
+
+	/// /////// ///
+	/// TESTING ///
+	/// /////// ///
+
+	// Test helper that compares two values with tolerance
+	void expectNear(float expected, float actual, float tolerance = 1e-5f,
+		const std::string& test_name = "") {
+		if (std::fabs(expected - actual) > tolerance) {
+			std::cerr << "Test failed: " << test_name
+				<< "\n  Expected: " << expected
+				<< "\n  Actual: " << actual
+				<< "\n  Diff: " << std::fabs(expected - actual)
+				<< "\n  Tolerance: " << tolerance << std::endl;
+		}
+		CHECK(expected == Catch::Approx(actual).margin(tolerance));
+	}
+
+	/// ///////////// ///
+	/// DATA CREATION ///
+	/// ///////////// ///
+
+	class DataGenerator {
+	public:
+		DataGenerator(const float range = 1.f) {
+			gen.seed(42);
+			dist = std::uniform_real_distribution<float>(-1.f * range, range);
+		}
+
+		// Helper function to generate random vector
+		std::vector<float> randomVector(size_t dim) {
+			std::vector<float> vec(dim);
+			for (size_t i = 0; i < dim; i++) {
+				vec[i] = dist(gen);
+			}
+			return vec;
+		}
+
+		// Helper function to generate constant vector
+		std::vector<float> constantVector(size_t dim, float value) {
+			return std::vector<float>(dim, value);
+		}
+
+		// Helper function to generate linearly increasing vector
+		std::vector<float> linearVector(size_t dim, float start = 0.0f, float step = 1.0f) {
+			std::vector<float> vec(dim);
+			for (size_t i = 0; i < dim; i++) {
+				vec[i] = start + i * step;
+			}
+			return vec;
+		}
+
+	private:
+		std::mt19937 gen;
+		std::uniform_real_distribution<float> dist;
+	};
+
+}


### PR DESCRIPTION
Adds a new metric based on [Pearson's correlation coefficient](https://en.wikipedia.org/wiki/Correlation) between data vectors: `1.0 - corr(A, B)`.  
- Equivalent to the correlation distance in [umap-learn](https://github.com/lmcinnes/umap/blob/15e55bb6a1ca23b8d6040d9d6184a7ae98325ace/umap/distances.py#L598). 
- Added test to show this equivalence